### PR TITLE
problem: macOS makefile breaks because of .so file

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,7 +1,7 @@
 build:
 	cd ffi && cargo build --release
 	cp ffi/target/release/libsputnikvm_ffi.a libsputnikvm.a
-	cp ffi/target/release/libsputnikvm_ffi.so libsputnikvm.so
+	cp ffi/target/release/libsputnikvm_ffi.so libsputnikvm.so | true
 
 build-musl:
 	cd ffi && docker run --rm -it -v "$(shell pwd)/ffi":/home/rust/src ekidd/rust-musl-builder cargo build --release
@@ -10,4 +10,4 @@ build-musl:
 debug:
 	cd ffi && cargo build
 	cp ffi/target/debug/libsputnikvm_ffi.a libsputnikvm.a
-	cp ffi/target/debug/libsputnikvm_ffi.so libsputnikvm.so
+	cp ffi/target/debug/libsputnikvm_ffi.so libsputnikvm.so | true

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,7 +1,6 @@
 build:
 	cd ffi && cargo build --release
 	cp ffi/target/release/libsputnikvm_ffi.a libsputnikvm.a
-	cp ffi/target/release/libsputnikvm_ffi.so libsputnikvm.so
 
 build-musl:
 	cd ffi && docker run --rm -it -v "$(shell pwd)/ffi":/home/rust/src ekidd/rust-musl-builder cargo build --release
@@ -10,4 +9,3 @@ build-musl:
 debug:
 	cd ffi && cargo build
 	cp ffi/target/debug/libsputnikvm_ffi.a libsputnikvm.a
-	cp ffi/target/debug/libsputnikvm_ffi.so libsputnikvm.so

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,6 +1,7 @@
 build:
 	cd ffi && cargo build --release
 	cp ffi/target/release/libsputnikvm_ffi.a libsputnikvm.a
+	cp ffi/target/release/libsputnikvm_ffi.so libsputnikvm.so
 
 build-musl:
 	cd ffi && docker run --rm -it -v "$(shell pwd)/ffi":/home/rust/src ekidd/rust-musl-builder cargo build --release
@@ -9,3 +10,4 @@ build-musl:
 debug:
 	cd ffi && cargo build
 	cp ffi/target/debug/libsputnikvm_ffi.a libsputnikvm.a
+	cp ffi/target/debug/libsputnikvm_ffi.so libsputnikvm.so


### PR DESCRIPTION
context:

```
$ cargo version
cargo 1.27.0 (1e95190e5 2018-05-27)

$ rustup --version
rustup 1.11.0 (e751ff9f8 2018-02-13)
```

solution: remove Makefile calls to that file

---

```
$ make install_geth
Installing $GOPATH/bin/geth
./scripts/build_sputnikvm.sh install
With SputnikVM, running geth install ...
Building SputnikVM
cd ffi && cargo build --release
    Finished release [optimized] target(s) in 0.28s
cp ffi/target/release/libsputnikvm_ffi.a libsputnikvm.a
cp ffi/target/release/libsputnikvm_ffi.so libsputnikvm.so
cp: ffi/target/release/libsputnikvm_ffi.so: No such file or directory
make[1]: *** [build] Error 1
make: *** [install_geth] Error 2
```

This happened to me since updating rust to above version.