### PR TITLE
Added two methods to obtain vm output

### DIFF
--- a/c/ffi/src/lib.rs
+++ b/c/ffi/src/lib.rs
@@ -779,3 +779,32 @@ pub extern "C" fn sputnikvm_status_failed(vm: *mut Box<VM>) -> c_uchar {
     Box::into_raw(vm_box);
     ret
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn sputnikvm_out_len(vm: *mut Box<VM>) -> c_uint {
+    let mut vm_box =  Box::from_raw(vm);
+    let ret;
+    {
+    let vm: &mut VM = vm_box.deref_mut().deref_mut();
+    ret=vm.out().len() as c_uint;
+    }
+    Box::into_raw(vm_box);
+    ret
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sputnikvm_out_copy_data(vm: *mut Box<VM>,w: *mut c_uchar) {
+    let mut vm_box =  Box::from_raw(vm);
+    {
+    let vm: &mut VM = vm_box.deref_mut().deref_mut();
+    let l=vm.out().len() as usize;
+    let mut w = slice::from_raw_parts_mut(w, l);
+    if l>0 {
+        let outputs = vm.out();        
+        for i in 0..l {
+            w[i] = outputs[i];
+        }
+    }
+    }
+    Box::into_raw(vm_box);
+}

--- a/c/sputnikvm.h
+++ b/c/sputnikvm.h
@@ -341,3 +341,16 @@ sputnikvm_default_header_params(void);
  */
 extern char
 sputnikvm_status_failed(sputnikvm_vm_t *vm);
+
+
+/**
+ * Returns len of output
+ */
+extern unsigned int
+sputnikvm_out_len(sputnikvm_vm_t *vm);
+
+/**
+ * Returns output
+ */
+extern void
+sputnikvm_out_copy_data(sputnikvm_vm_t *vm,unsigned char *w);

--- a/go/main.go
+++ b/go/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 	"math/big"
-	"github.com/ethereumproject/go-ethereum/common"
+
 	"github.com/ETCDEVTeam/sputnikvm-ffi/go/sputnikvm"
+	"github.com/ethereumproject/go-ethereum/common"
 )
 
 func main() {
@@ -13,22 +14,22 @@ func main() {
 	fmt.Printf("%v\n", cint)
 	sputnikvm.PrintCU256(cint)
 
-	transaction := sputnikvm.Transaction {
-		Caller: *new(common.Address),
+	transaction := sputnikvm.Transaction{
+		Caller:   *new(common.Address),
 		GasPrice: new(big.Int),
 		GasLimit: new(big.Int).SetUint64(1000000000),
-		Address: new(common.Address),
-		Value: new(big.Int),
-		Input: []byte{1, 2, 3, 4, 5},
-		Nonce: new(big.Int),
+		Address:  new(common.Address),
+		Value:    new(big.Int),
+		Input:    []byte{1, 2, 3, 4, 5},
+		Nonce:    new(big.Int),
 	}
 
-	header := sputnikvm.HeaderParams {
+	header := sputnikvm.HeaderParams{
 		Beneficiary: *new(common.Address),
-		Timestamp: 0,
-		Number: new(big.Int),
-		Difficulty: new(big.Int),
-		GasLimit: new(big.Int),
+		Timestamp:   0,
+		Number:      new(big.Int),
+		Difficulty:  new(big.Int),
+		GasLimit:    new(big.Int),
 	}
 
 	vm := sputnikvm.NewFrontier(&transaction, &header)
@@ -53,5 +54,6 @@ Loop:
 	fmt.Printf("%v\n", vm.UsedGas())
 	fmt.Printf("%v\n", vm.Logs())
 	fmt.Printf("%v\n", vm.AccountChanges())
+	//fmt.Printf("%s\n", hex.EncodeToString(vm.Output()))
 	vm.Free()
 }

--- a/go/sputnikvm/sputnikvm.go
+++ b/go/sputnikvm/sputnikvm.go
@@ -33,9 +33,10 @@ package sputnikvm
 import "C"
 
 import (
-	"github.com/ethereumproject/go-ethereum/common"
 	"math/big"
 	"unsafe"
+
+	"github.com/ethereumproject/go-ethereum/common"
 )
 
 type AccountChangeType int
@@ -666,4 +667,21 @@ func (vm *VM) AccountChanges() []AccountChange {
 
 func (vm *VM) Failed() bool {
 	return uint(C.sputnikvm_status_failed(vm.c)) == 1
+}
+
+func (vm *VM) OutLen() uint {
+	return uint(C.sputnikvm_out_len(vm.c))
+}
+
+func (vm *VM) Output() []uint8 {
+	l := uint(C.sputnikvm_out_len(vm.c))
+	cout := C.malloc(C.size_t(l))
+	C.sputnikvm_out_copy_data(vm.c, (*C.uchar)(cout))
+	out := make([]uint8, int(l))
+
+	for j := 0; j < int(l); j++ {
+		j_cout := unsafe.Pointer(uintptr(cout) + uintptr(j))
+		out[j] = uint8(*(*C.uchar)(j_cout))
+	}
+	return out
 }


### PR DESCRIPTION
Since we are using Sputnik as a stateless evm in our blockchain we needed to expose the Sputnik vm's output to the golang wrapper.
1-Added two methods (sputnikvm_out_len(), sputnikvm_out_copy_data() ) to the "lib.rs".
2-Defined two mentioned methods to "sputnikvm.h".
3-Added OutLen() and Output() to the VM class in "sputnikvm.go".